### PR TITLE
Initialize chart once and update data

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -70,7 +70,18 @@
       // UI state
       $('#api').value = new URLSearchParams(location.search).get('api') || 'http://localhost:3000';
       let timer = null;
-      let routeChart = null;
+      const routeChart = new Chart(
+        document.getElementById('routeChart').getContext('2d'),
+        {
+          type: 'bar',
+          data: { labels: [], datasets: [{ label: 'Requests', data: [] }] },
+          options: {
+            responsive: true,
+            plugins: { legend: { display: false } },
+            scales: { x: { ticks: { autoSkip: false } } }
+          }
+        }
+      );
 
       async function fetchStatsOnce() {
         const base = getBaseUrl();
@@ -119,17 +130,9 @@
           counts.push(r.count);
         });
 
-        const ctx = document.getElementById('routeChart').getContext('2d');
-        if (routeChart) routeChart.destroy();
-        routeChart = new Chart(ctx, {
-          type: 'bar',
-          data: { labels, datasets: [{ label: 'Requests', data: counts }] },
-          options: {
-            responsive: true,
-            plugins: { legend: { display: false } },
-            scales: { x: { ticks: { autoSkip: false } } }
-          }
-        });
+        routeChart.data.labels = labels;
+        routeChart.data.datasets[0].data = counts;
+        routeChart.update();
 
         // recent
         const rct = $('#recentTable');


### PR DESCRIPTION
## Summary
- Initialize route chart once on page load
- Update chart data in render and call update instead of recreating
- Remove chart destruction logic

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af71a5cac88324a7197610f5cc47e2