### PR TITLE
docs: update URLs and improve start page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Eine kleine Beispiel‑API zum **Üben von REST‑Basics** – mit Demo‑Datenm
 
 > Ziel: Einsteiger:innen sollen schnell Requests testen (GET/POST/PATCH/DELETE), typische Fehler verstehen und direkt ein Gefühl für eine API bekommen.
 
+**Live Demo:** https://api-demo-l4rk.onrender.com – inkl. Dashboard und [API‑Doku](https://api-demo-l4rk.onrender.com/docs).
+
 ---
 
 ## 1) Schnellstart
@@ -16,11 +18,12 @@ cd rest-api-demo
 npm install
 # optional: eigenen API-Key setzen, sonst Default
 API_KEY=my-secret npm start
-# öffne im Browser: http://localhost:3000/
+# öffne im Browser: https://api-demo-l4rk.onrender.com/
 ```
 
-- **Landing Page:** Übersicht & Links → `http://localhost:3000/`
-- **Dashboard:** Live‑Stats → `http://localhost:3000/dashboard` (pollt `/api/_stats` alle 2s)
+- **Landing Page:** Übersicht & Links → `https://api-demo-l4rk.onrender.com/`
+- **Dashboard:** Live‑Stats → `https://api-demo-l4rk.onrender.com/dashboard` (pollt `/api/_stats` alle 2s)
+- **Docs:** OpenAPI → `https://api-demo-l4rk.onrender.com/docs`
 
 **Standard‑Ports/Variablen**
 - `PORT` – Port der App (default: `3000`)
@@ -56,7 +59,7 @@ Beziehungen:
 
 **Beispiel:**
 ```bash
-curl -s -X POST http://localhost:3000/api/todos \
+curl -s -X POST https://api-demo-l4rk.onrender.com/api/todos \
   -H "X-API-Key: my-secret" \
   -H "Content-Type: application/json" \
   -d '{"userId":"1","title":"Secured task"}'
@@ -83,13 +86,13 @@ curl -s -X POST http://localhost:3000/api/todos \
 
 **Beispiel (lesen):**
 ```bash
-curl -s http://localhost:3000/api/users
-curl -s "http://localhost:3000/api/users?q=ali"
+curl -s https://api-demo-l4rk.onrender.com/api/users
+curl -s "https://api-demo-l4rk.onrender.com/api/users?q=ali"
 ```
 
 **Beispiel (anlegen):**
 ```bash
-curl -s -X POST http://localhost:3000/api/users \
+curl -s -X POST https://api-demo-l4rk.onrender.com/api/users \
   -H "X-API-Key: my-secret" \
   -H "Content-Type: application/json" \
   -d '{"name":"Charlie","email":"charlie@example.com"}'
@@ -105,15 +108,15 @@ curl -s -X POST http://localhost:3000/api/users \
 
 **Beispiele (lesen):**
 ```bash
-curl -s http://localhost:3000/api/todos
-curl -s "http://localhost:3000/api/todos?userId=1"
-curl -s "http://localhost:3000/api/todos?completed=true"
+curl -s https://api-demo-l4rk.onrender.com/api/todos
+curl -s "https://api-demo-l4rk.onrender.com/api/todos?userId=1"
+curl -s "https://api-demo-l4rk.onrender.com/api/todos?completed=true"
 ```
 
 **Beispiel (ändern):**
 ```bash
 # Todo 3 erledigt setzen
-curl -s -X PATCH http://localhost:3000/api/todos/3 \
+curl -s -X PATCH https://api-demo-l4rk.onrender.com/api/todos/3 \
   -H "X-API-Key: my-secret" \
   -H "Content-Type: application/json" \
   -d '{"completed": true}'
@@ -141,7 +144,7 @@ curl -s -X PATCH http://localhost:3000/api/todos/3 \
 
 ## 6) Mit Postman/Insomnia testen
 
-1. **Neue Collection** anlegen, Basis‑URL `http://localhost:3000` setzen.
+1. **Neue Collection** anlegen, Basis‑URL `https://api-demo-l4rk.onrender.com` setzen.
 2. **GET‑Requests** ohne Auth testen (z. B. `/api/users`).
 3. Für **POST/PATCH/DELETE** als Header hinzufügen:
    - `X-API-Key: my-secret` (oder `Authorization: ApiKey my-secret`)
@@ -204,6 +207,6 @@ rest-api-demo/
 
 ## OpenAPI / Swagger
 
-- **Spec:** `GET /openapi.json`
-- **UI:** `GET /docs` – interaktive Oberfläche zum Ausprobieren der Endpunkte (Swagger UI)
+- **Spec:** `GET https://api-demo-l4rk.onrender.com/openapi.json`
+- **UI:** `GET https://api-demo-l4rk.onrender.com/docs` – interaktive Oberfläche zum Ausprobieren der Endpunkte (Swagger UI)
 - **Tipp:** Für geschützte Endpunkte im **Authorize**‑Dialog `X-API-Key` setzen oder Header manuell ergänzen.

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -31,7 +31,7 @@
       <h1>API Dashboard</h1>
       <div class="controls">
         <label for="api">API Base URL:</label>
-        <input id="api" type="text" placeholder="http://localhost:3000" />
+        <input id="api" type="text" placeholder="https://api-demo-l4rk.onrender.com" />
         <button id="apply">Verbinden</button>
         <label><input id="hideStats" type="checkbox" checked /> /stats ausblenden</label>
         <span id="status" class="small"></span>
@@ -65,11 +65,11 @@
 
       function getBaseUrl() {
         const p = new URLSearchParams(location.search);
-        return (p.get('api') || $('#api').value || 'http://localhost:3000').replace(/\/+$/,''); // trim trailing slash
+        return (p.get('api') || $('#api').value || 'https://api-demo-l4rk.onrender.com').replace(/\/+$/,''); // trim trailing slash
       }
 
       // UI state
-      $('#api').value = new URLSearchParams(location.search).get('api') || 'http://localhost:3000';
+      $('#api').value = new URLSearchParams(location.search).get('api') || 'https://api-demo-l4rk.onrender.com';
       let timer = null;
       let lastData = null;
       const routeChart = new Chart(
@@ -166,7 +166,7 @@
       }
 
       $('#apply').addEventListener('click', () => {
-        const api = $('#api').value || 'http://localhost:3000';
+        const api = $('#api').value || 'https://api-demo-l4rk.onrender.com';
         const url = new URL(location.href);
         url.searchParams.set('api', api);
         history.replaceState(null, '', url.toString());

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -7,8 +7,8 @@
   },
   "servers": [
     {
-      "url": "http://localhost:3000",
-      "description": "Local dev"
+      "url": "https://api-demo-l4rk.onrender.com",
+      "description": "Demo"
     }
   ],
   "components": {

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,18 @@
+*{box-sizing:border-box}
+body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif;background:#0b0c10;color:#eaeaea;line-height:1.5}
+a{color:#61dafb}
+main.container{max-width:700px;margin:0 auto;padding:40px 24px;text-align:center}
+h1{font-size:2.2rem;margin-bottom:0.5em}
+ul{list-style:none;padding:0}
+li{margin:0.4em 0}
+.btn{
+  display:inline-block;
+  margin-top:1.2em;
+  padding:8px 16px;
+  background:#1f6feb;
+  color:#fff;
+  border-radius:8px;
+  text-decoration:none;
+}
+.btn:hover{background:#388bfd}
+.small{font-size:0.875rem;opacity:.8;margin-top:1.2em}

--- a/server.js
+++ b/server.js
@@ -228,14 +228,15 @@ app.get("/", (_req, res) => {
       <body>
         <main class="container">
           <h1>REST API Demo</h1>
-          <p>Example endpoints:</p>
+          <p>Beispiel‑API mit Users & Todos.</p>
           <ul>
             <li><a href="/api/health" target="_blank">GET /api/health</a></li>
             <li><a href="/api/users" target="_blank">GET /api/users</a></li>
             <li><a href="/api/todos" target="_blank">GET /api/todos</a></li>
             <li><a href="/dashboard" target="_blank">Dashboard</a></li>
           </ul>
-          <p>This app keeps data in memory. Restarting the server resets the data.</p>
+          <a class="btn" href="/docs" target="_blank">API Docs</a>
+          <p class="small">Daten werden nur im Speicher gehalten und beim Neustart zurückgesetzt.</p>
         </main>
       </body>
     </html>
@@ -248,7 +249,7 @@ app.get("/dashboard", (_req, res) => {
 });
 
 app.listen(PORT, () => {
-  console.log(`REST API Demo listening on http://localhost:${PORT}`);
+  console.log(`REST API Demo listening on port ${PORT}`);
 });
 
 


### PR DESCRIPTION
## Summary
- document live demo and swagger docs
- restyle start page and add docs link
- replace localhost URLs with https://api-demo-l4rk.onrender.com

## Testing
- `npm test` (fails: Missing script "test")
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68af7793cbac8324a14ed6b0415fe579